### PR TITLE
external/esp_idf_port: add ESP32 event loop module.

### DIFF
--- a/external/esp_idf_port/esp32/event_loop/event_default_handlers.c
+++ b/external/esp_idf_port/esp32/event_loop/event_default_handlers.c
@@ -1,0 +1,383 @@
+/******************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************/
+
+// Copyright 2015-2016 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "esp_err.h"
+#include "esp_wifi.h"
+#include "esp_wifi_internal.h"
+#include "esp_event.h"
+#include "esp_event_loop.h"
+#include "esp_task.h"
+#include "esp_log.h"
+#include "esp_system.h"
+#include "lwip/dhcp.h"
+#include "lwip/prot/dhcp.h"
+#include "rom/ets_sys.h"
+#if 0
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/queue.h"
+#include "freertos/semphr.h"
+#endif
+#include "tcpip_adapter.h"
+#include "esp_log.h"
+
+#define DHCP_TIMEOUT (5)
+
+static const char *TAG = "event";
+static int dhcp_timeleft = DHCP_TIMEOUT;
+extern struct dhcp g_dhcp_handle;
+
+#define WIFI_API_CALL_CHECK(info, api_call, ret) \
+do{\
+    esp_err_t __err = (api_call);\
+    if ((ret) != __err) {\
+        ESP_LOGE(TAG, "%s %d %s ret=0x%X", __FUNCTION__, __LINE__, (info), __err);\
+        return __err;\
+    }\
+} while(0)
+
+typedef esp_err_t(*system_event_handler_t)(system_event_t *e);
+
+static esp_err_t system_event_ap_start_handle_default(system_event_t *event);
+static esp_err_t system_event_ap_stop_handle_default(system_event_t *event);
+static esp_err_t system_event_sta_start_handle_default(system_event_t *event);
+static esp_err_t system_event_sta_stop_handle_default(system_event_t *event);
+static esp_err_t system_event_sta_connected_handle_default(system_event_t *event);
+static esp_err_t system_event_sta_disconnected_handle_default(system_event_t *event);
+static esp_err_t system_event_sta_got_ip_default(system_event_t *event);
+static esp_err_t system_event_sta_lost_ip_default(system_event_t *event);
+/* Default event handler functions
+
+   Any entry in this table which is disabled by config will have a NULL handler.
+*/
+static system_event_handler_t default_event_handlers[SYSTEM_EVENT_MAX] = { 0 };
+
+static esp_err_t system_event_sta_got_ip_default(system_event_t *event)
+{
+	WIFI_API_CALL_CHECK("esp_wifi_internal_set_sta_ip", esp_wifi_internal_set_sta_ip(), ESP_OK);
+
+	ESP_LOGI(TAG, "sta ip: " IPSTR ", mask: " IPSTR ", gw: " IPSTR, IP2STR(&event->event_info.got_ip.ip_info.ip), IP2STR(&event->event_info.got_ip.ip_info.netmask), IP2STR(&event->event_info.got_ip.ip_info.gw));
+
+	return ESP_OK;
+}
+
+static esp_err_t system_event_sta_lost_ip_default(system_event_t *event)
+{
+	ESP_LOGI(TAG, "station ip lost");
+	return ESP_OK;
+}
+
+esp_err_t system_event_ap_start_handle_default(system_event_t *event)
+{
+	tcpip_adapter_ip_info_t ap_ip;
+	uint8_t ap_mac[6];
+
+	WIFI_API_CALL_CHECK("esp_wifi_internal_reg_rxcb", esp_wifi_internal_reg_rxcb(ESP_IF_WIFI_AP, (wifi_rxcb_t) tcpip_adapter_ap_input), ESP_OK);
+	WIFI_API_CALL_CHECK("esp_wifi_mac_get", esp_wifi_get_mac(ESP_IF_WIFI_AP, ap_mac), ESP_OK);
+
+	tcpip_adapter_get_ip_info(TCPIP_ADAPTER_IF_AP, &ap_ip);
+	tcpip_adapter_ap_start(ap_mac, &ap_ip);
+
+	return ESP_OK;
+}
+
+esp_err_t system_event_ap_stop_handle_default(system_event_t *event)
+{
+	WIFI_API_CALL_CHECK("esp_wifi_internal_reg_rxcb", esp_wifi_internal_reg_rxcb(ESP_IF_WIFI_AP, NULL), ESP_OK);
+
+	tcpip_adapter_stop(TCPIP_ADAPTER_IF_AP);
+
+	return ESP_OK;
+}
+
+esp_err_t system_event_sta_start_handle_default(system_event_t *event)
+{
+	tcpip_adapter_ip_info_t sta_ip;
+	uint8_t sta_mac[6];
+
+	WIFI_API_CALL_CHECK("esp_wifi_mac_get", esp_wifi_get_mac(ESP_IF_WIFI_STA, sta_mac), ESP_OK);
+	tcpip_adapter_get_ip_info(TCPIP_ADAPTER_IF_STA, &sta_ip);
+	tcpip_adapter_sta_start(sta_mac, &sta_ip);
+
+	return ESP_OK;
+}
+
+esp_err_t system_event_sta_stop_handle_default(system_event_t *event)
+{
+	tcpip_adapter_stop(TCPIP_ADAPTER_IF_STA);
+
+	return ESP_OK;
+}
+
+static void check_dhcp_status(tcpip_adapter_if_t tcpip_if)
+{
+	ESP_LOGI(TAG, "try to get ip address\n");
+	tcpip_adapter_if_t *sta_if;
+	tcpip_adapter_get_netif(tcpip_if, &sta_if);
+
+	dhcp_timeleft = DHCP_TIMEOUT;
+	while (g_dhcp_handle.state != DHCP_STATE_BOUND) {
+		sleep(1);
+		dhcp_timeleft -= 1;
+		if (dhcp_timeleft <= 0) {
+			break;
+		}
+	}
+	if (g_dhcp_handle.state == DHCP_STATE_BOUND) {
+
+		ESP_LOGI(TAG, "got ip address\n");
+		tcpip_adapter_dhcpc_notify(sta_if);
+	} else {
+		if (dhcp_timeleft <= 0) {
+			ESP_LOGI(TAG, "DHCP Client - Timeout fail to get ip address\n");
+			return ESP_FAIL;
+		}
+	}
+	ESP_LOGI(TAG, "dhcp client start successfully");
+	return ESP_OK;
+
+}
+
+esp_err_t system_event_sta_connected_handle_default(system_event_t *event)
+{
+	tcpip_adapter_dhcp_status_t status;
+
+	WIFI_API_CALL_CHECK("esp_wifi_internal_reg_rxcb", esp_wifi_internal_reg_rxcb(ESP_IF_WIFI_STA, (wifi_rxcb_t) tcpip_adapter_sta_input), ESP_OK);
+
+	tcpip_adapter_up(TCPIP_ADAPTER_IF_STA);
+
+	tcpip_adapter_dhcpc_get_status(TCPIP_ADAPTER_IF_STA, &status);
+
+	if (status == TCPIP_ADAPTER_DHCP_INIT) {
+		tcpip_adapter_dhcpc_start(TCPIP_ADAPTER_IF_STA);
+		check_dhcp_status(TCPIP_ADAPTER_IF_STA);
+
+	} else if (status == TCPIP_ADAPTER_DHCP_STOPPED) {
+		tcpip_adapter_ip_info_t sta_ip;
+		tcpip_adapter_ip_info_t sta_old_ip;
+
+		tcpip_adapter_get_ip_info(TCPIP_ADAPTER_IF_STA, &sta_ip);
+		tcpip_adapter_get_old_ip_info(TCPIP_ADAPTER_IF_STA, &sta_old_ip);
+
+		if (!(ip4_addr_isany_val(sta_ip.ip) || ip4_addr_isany_val(sta_ip.netmask))) {
+			system_event_t evt;
+
+			evt.event_id = SYSTEM_EVENT_STA_GOT_IP;
+			evt.event_info.got_ip.ip_changed = false;
+
+			if (memcmp(&sta_ip, &sta_old_ip, sizeof(sta_ip))) {
+				evt.event_info.got_ip.ip_changed = true;
+			}
+
+			memcpy(&evt.event_info.got_ip.ip_info, &sta_ip, sizeof(tcpip_adapter_ip_info_t));
+			tcpip_adapter_set_old_ip_info(TCPIP_ADAPTER_IF_STA, &sta_ip);
+
+			esp_event_send(&evt);
+			ESP_LOGD(TAG, "static ip: ip changed=%d", evt.event_info.got_ip.ip_changed);
+		} else {
+			ESP_LOGE(TAG, "invalid static ip");
+		}
+	}
+
+	return ESP_OK;
+}
+
+esp_err_t system_event_sta_disconnected_handle_default(system_event_t *event)
+{
+	WIFI_API_CALL_CHECK("esp_wifi_internal_reg_rxcb", esp_wifi_internal_reg_rxcb(ESP_IF_WIFI_STA, NULL), ESP_OK);
+	return ESP_OK;
+}
+
+static esp_err_t esp_system_event_debug(system_event_t *event)
+{
+	if (event == NULL) {
+		ESP_LOGE(TAG, "event is null!");
+		return ESP_FAIL;
+	}
+
+	switch (event->event_id) {
+	case SYSTEM_EVENT_WIFI_READY: {
+		ESP_LOGD(TAG, "SYSTEM_EVENT_WIFI_READY");
+		break;
+	}
+	case SYSTEM_EVENT_SCAN_DONE: {
+		system_event_sta_scan_done_t *scan_done = &event->event_info.scan_done;
+		ESP_LOGD(TAG, "SYSTEM_EVENT_SCAN_DONE, status:%d, number:%d", scan_done->status, scan_done->number);
+		break;
+	}
+	case SYSTEM_EVENT_STA_START: {
+		ESP_LOGD(TAG, "SYSTEM_EVENT_STA_START");
+		break;
+	}
+	case SYSTEM_EVENT_STA_STOP: {
+		ESP_LOGD(TAG, "SYSTEM_EVENT_STA_STOP");
+		break;
+	}
+	case SYSTEM_EVENT_STA_CONNECTED: {
+		system_event_sta_connected_t *connected = &event->event_info.connected;
+		ESP_LOGD(TAG, "SYSTEM_EVENT_STA_CONNECTED, ssid:%s, ssid_len:%d, bssid:" MACSTR ", channel:%d, authmode:%d", connected->ssid, connected->ssid_len, MAC2STR(connected->bssid), connected->channel, connected->authmode);
+		break;
+	}
+	case SYSTEM_EVENT_STA_DISCONNECTED: {
+		system_event_sta_disconnected_t *disconnected = &event->event_info.disconnected;
+		ESP_LOGD(TAG, "SYSTEM_EVENT_STA_DISCONNECTED, ssid:%s, ssid_len:%d, bssid:" MACSTR ", reason:%d\n", disconnected->ssid, disconnected->ssid_len, MAC2STR(disconnected->bssid), disconnected->reason);
+		break;
+	}
+	case SYSTEM_EVENT_STA_AUTHMODE_CHANGE: {
+		system_event_sta_authmode_change_t *auth_change = &event->event_info.auth_change;
+		ESP_LOGD(TAG, "SYSTEM_EVENT_STA_AUTHMODE_CHNAGE, old_mode:%d, new_mode:%d", auth_change->old_mode, auth_change->new_mode);
+		break;
+	}
+	case SYSTEM_EVENT_STA_GOT_IP: {
+		system_event_sta_got_ip_t *got_ip = &event->event_info.got_ip;
+		ESP_LOGD(TAG, "SYSTEM_EVENT_STA_GOT_IP, ip:" IPSTR ", mask:" IPSTR ", gw:" IPSTR, IP2STR(&got_ip->ip_info.ip), IP2STR(&got_ip->ip_info.netmask), IP2STR(&got_ip->ip_info.gw));
+		break;
+	}
+	case SYSTEM_EVENT_STA_LOST_IP: {
+		ESP_LOGD(TAG, "SYSTEM_EVENT_STA_LOST_IP");
+		break;
+	}
+	case SYSTEM_EVENT_STA_WPS_ER_SUCCESS: {
+		ESP_LOGD(TAG, "SYSTEM_EVENT_STA_WPS_ER_SUCCESS");
+		break;
+	}
+	case SYSTEM_EVENT_STA_WPS_ER_FAILED: {
+		ESP_LOGD(TAG, "SYSTEM_EVENT_STA_WPS_ER_FAILED");
+		break;
+	}
+	case SYSTEM_EVENT_STA_WPS_ER_TIMEOUT: {
+		ESP_LOGD(TAG, "SYSTEM_EVENT_STA_WPS_ER_TIMEOUT");
+		break;
+	}
+	case SYSTEM_EVENT_STA_WPS_ER_PIN: {
+		ESP_LOGD(TAG, "SYSTEM_EVENT_STA_WPS_ER_PIN");
+		break;
+	}
+	case SYSTEM_EVENT_AP_START: {
+		ESP_LOGD(TAG, "SYSTEM_EVENT_AP_START");
+		break;
+	}
+	case SYSTEM_EVENT_AP_STOP: {
+		ESP_LOGD(TAG, "SYSTEM_EVENT_AP_STOP");
+		break;
+	}
+	case SYSTEM_EVENT_AP_STACONNECTED: {
+		system_event_ap_staconnected_t *staconnected = &event->event_info.sta_connected;
+		ESP_LOGD(TAG, "SYSTEM_EVENT_AP_STACONNECTED, mac:" MACSTR ", aid:%d", MAC2STR(staconnected->mac), staconnected->aid);
+		break;
+	}
+	case SYSTEM_EVENT_AP_STADISCONNECTED: {
+		system_event_ap_stadisconnected_t *stadisconnected = &event->event_info.sta_disconnected;
+		ESP_LOGD(TAG, "SYSTEM_EVENT_AP_STADISCONNECTED, mac:" MACSTR ", aid:%d", MAC2STR(stadisconnected->mac), stadisconnected->aid);
+		break;
+	}
+	case SYSTEM_EVENT_AP_STAIPASSIGNED: {
+		ESP_LOGD(TAG, "SYSTEM_EVENT_AP_STAIPASSIGNED");
+		break;
+	}
+	case SYSTEM_EVENT_AP_PROBEREQRECVED: {
+		system_event_ap_probe_req_rx_t *ap_probereqrecved = &event->event_info.ap_probereqrecved;
+		ESP_LOGD(TAG, "SYSTEM_EVENT_AP_PROBEREQRECVED, rssi:%d, mac:" MACSTR, ap_probereqrecved->rssi, MAC2STR(ap_probereqrecved->mac));
+		break;
+	}
+	case SYSTEM_EVENT_GOT_IP6: {
+		ip6_addr_t *addr = &event->event_info.got_ip6.ip6_info.ip;
+		ESP_LOGD(TAG, "SYSTEM_EVENT_AP_STA_GOT_IP6 address %04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x", IP6_ADDR_BLOCK1(addr), IP6_ADDR_BLOCK2(addr), IP6_ADDR_BLOCK3(addr), IP6_ADDR_BLOCK4(addr), IP6_ADDR_BLOCK5(addr), IP6_ADDR_BLOCK6(addr), IP6_ADDR_BLOCK7(addr), IP6_ADDR_BLOCK8(addr));
+		break;
+	}
+	case SYSTEM_EVENT_ETH_START: {
+		ESP_LOGD(TAG, "SYSTEM_EVENT_ETH_START");
+		break;
+	}
+	case SYSTEM_EVENT_ETH_STOP: {
+		ESP_LOGD(TAG, "SYSTEM_EVENT_ETH_STOP");
+		break;
+	}
+	case SYSTEM_EVENT_ETH_CONNECTED: {
+		ESP_LOGD(TAG, "SYSTEM_EVENT_ETH_CONNECETED");
+		break;
+	}
+	case SYSTEM_EVENT_ETH_DISCONNECTED: {
+		ESP_LOGD(TAG, "SYSTEM_EVENT_ETH_DISCONNECETED");
+		break;
+	}
+	case SYSTEM_EVENT_ETH_GOT_IP: {
+		ESP_LOGD(TAG, "SYSTEM_EVENT_ETH_GOT_IP");
+		break;
+	}
+
+	default: {
+		ESP_LOGW(TAG, "unexpected system event %d!", event->event_id);
+		break;
+	}
+	}
+
+	return ESP_OK;
+}
+
+esp_err_t esp_event_process_default(system_event_t *event)
+{
+	if (event == NULL) {
+		ESP_LOGE(TAG, "Error: event is null!");
+		return ESP_FAIL;
+	}
+
+	esp_system_event_debug(event);
+	if ((event->event_id < SYSTEM_EVENT_MAX)) {
+		if (default_event_handlers[event->event_id] != NULL) {
+			default_event_handlers[event->event_id](event);
+		}
+	} else {
+		ESP_LOGE(TAG, "mismatch or invalid event, id=%d", event->event_id);
+		return ESP_FAIL;
+	}
+	return ESP_OK;
+}
+
+void esp_event_set_default_wifi_handlers()
+{
+	default_event_handlers[SYSTEM_EVENT_STA_START] = system_event_sta_start_handle_default;
+	default_event_handlers[SYSTEM_EVENT_STA_STOP] = system_event_sta_stop_handle_default;
+	default_event_handlers[SYSTEM_EVENT_STA_CONNECTED] = system_event_sta_connected_handle_default;
+	default_event_handlers[SYSTEM_EVENT_STA_DISCONNECTED] = system_event_sta_disconnected_handle_default;
+	default_event_handlers[SYSTEM_EVENT_STA_GOT_IP] = system_event_sta_got_ip_default;
+	default_event_handlers[SYSTEM_EVENT_STA_LOST_IP] = system_event_sta_lost_ip_default;
+	default_event_handlers[SYSTEM_EVENT_AP_START] = system_event_ap_start_handle_default;
+	default_event_handlers[SYSTEM_EVENT_AP_STOP] = system_event_ap_stop_handle_default;
+
+	esp_register_shutdown_handler((shutdown_handler_t) esp_wifi_stop);
+}
+#endif

--- a/external/esp_idf_port/esp32/event_loop/event_loop.c
+++ b/external/esp_idf_port/esp32/event_loop/event_loop.c
@@ -1,0 +1,144 @@
+/******************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************/
+
+// Copyright 2015-2016 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "esp_err.h"
+#include "esp_wifi.h"
+#include "esp_event.h"
+#include "esp_event_loop.h"
+#include "esp_task.h"
+#include "esp_mesh.h"
+#include "esp_wifi_os_adapter.h"
+#include "esp_log.h"
+#include <unistd.h>
+
+#define TAG "eventloop"
+#define portMAX_DELAY (0xffffffff)
+static bool s_event_init_flag = false;
+static void *s_event_queue = NULL;
+static system_event_cb_t s_event_handler_cb = NULL;
+static void *s_event_ctx = NULL;
+static int g_event_thread_pid;
+
+static esp_err_t esp_event_post_to_user(system_event_t *event)
+{
+	if (s_event_handler_cb) {
+		return (*s_event_handler_cb)(s_event_ctx, event);
+	}
+	return ESP_OK;
+}
+
+static void esp_event_loop_task(void *pvParameters)
+{
+	while (1) {
+		system_event_t evt;
+		esp_err_t ret;
+		if (g_wifi_osi_funcs._queue_recv(s_event_queue, &evt, portMAX_DELAY) == pdPASS) {
+			esp_err_t ret = esp_event_process_default(&evt);
+			if (ret != ESP_OK) {
+				ESP_LOGE(TAG, "default event handler failed!");
+			}
+			ret = esp_event_post_to_user(&evt);
+			if (ret != ESP_OK) {
+				ESP_LOGE(TAG, "post event to user fail!");
+			}
+		}
+	}
+}
+
+system_event_cb_t esp_event_loop_set_cb(system_event_cb_t cb, void *ctx)
+{
+	system_event_cb_t old_cb = s_event_handler_cb;
+	s_event_handler_cb = cb;
+	s_event_ctx = ctx;
+	return old_cb;
+}
+
+esp_err_t esp_event_send(system_event_t *event)
+{
+	if (s_event_queue == NULL) {
+		ESP_LOGE(TAG, "Event loop not initialized via esp_event_loop_init, but esp_event_send called");
+		return ESP_ERR_INVALID_STATE;
+	}
+	if (event->event_id == SYSTEM_EVENT_STA_GOT_IP || event->event_id == SYSTEM_EVENT_STA_LOST_IP) {
+		if (g_mesh_event_cb) {
+			mesh_event_t mevent;
+			if (event->event_id == SYSTEM_EVENT_STA_GOT_IP) {
+				mevent.id = MESH_EVENT_ROOT_GOT_IP;
+				memcpy(&mevent.info.got_ip, &event->event_info.got_ip, sizeof(system_event_sta_got_ip_t));
+			} else {
+				mevent.id = MESH_EVENT_ROOT_LOST_IP;
+			}
+			g_mesh_event_cb(mevent);
+		}
+	}
+	int32_t ret = g_wifi_osi_funcs._queue_send_to_back(s_event_queue, event, 1);
+	if (ret != pdPASS) {
+		if (event) {
+            ESP_LOGE(TAG, "e=%d f", event->event_id);
+		} else {
+            ESP_LOGE(TAG, "e null");
+		}
+		return ESP_FAIL;
+	}
+	return ESP_OK;
+}
+
+void *esp_event_loop_get_queue(void)
+{
+	return s_event_queue;
+}
+
+esp_err_t esp_event_loop_init(system_event_cb_t cb, void *ctx)
+{
+	if (s_event_init_flag) {
+		return ESP_FAIL;
+	}
+	s_event_handler_cb = cb;
+	s_event_ctx = ctx;
+	s_event_queue = g_wifi_osi_funcs._queue_create(CONFIG_SYSTEM_EVENT_QUEUE_SIZE, sizeof(system_event_t));
+
+	g_wifi_osi_funcs._task_create_pinned_to_core(esp_event_loop_task, "eventTask", ESP_TASKD_EVENT_STACK, NULL, ESP_TASKD_EVENT_PRIO, (void *)&g_event_thread_pid, 0);
+
+	s_event_init_flag = true;
+	return ESP_OK;
+}
+
+void esp_event_loop_deinit(void)
+{
+	g_wifi_osi_funcs._task_delete(g_event_thread_pid);
+	g_wifi_osi_funcs._queue_delete(s_event_queue);
+	s_event_init_flag = false;
+}

--- a/external/esp_idf_port/include/esp_event.h
+++ b/external/esp_idf_port/include/esp_event.h
@@ -1,0 +1,234 @@
+/******************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************/
+
+// Copyright 2015-2016 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef __ESP_EVENT_H__
+#define __ESP_EVENT_H__
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "esp_err.h"
+#include "esp_wifi_types.h"
+#include "tcpip_adapter.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+	typedef enum {
+		SYSTEM_EVENT_WIFI_READY = 0,
+								   /**< ESP32 WiFi ready */
+		SYSTEM_EVENT_SCAN_DONE,	   /**< ESP32 finish scanning AP */
+		SYSTEM_EVENT_STA_START,	   /**< ESP32 station start */
+		SYSTEM_EVENT_STA_STOP,	   /**< ESP32 station stop */
+		SYSTEM_EVENT_STA_CONNECTED,/**< ESP32 station connected to AP */
+		SYSTEM_EVENT_STA_DISCONNECTED,
+								   /**< ESP32 station disconnected from AP */
+		SYSTEM_EVENT_STA_AUTHMODE_CHANGE,
+	/**< the auth mode of AP connected by ESP32 station changed */
+		SYSTEM_EVENT_STA_GOT_IP,   /**< ESP32 station got IP from connected AP */
+		SYSTEM_EVENT_STA_LOST_IP,  /**< ESP32 station lost IP and the IP is reset to 0 */
+		SYSTEM_EVENT_STA_WPS_ER_SUCCESS,
+	/**< ESP32 station wps succeeds in enrollee mode */
+		SYSTEM_EVENT_STA_WPS_ER_FAILED,
+								   /**< ESP32 station wps fails in enrollee mode */
+		SYSTEM_EVENT_STA_WPS_ER_TIMEOUT,
+	/**< ESP32 station wps timeout in enrollee mode */
+		SYSTEM_EVENT_STA_WPS_ER_PIN,
+								   /**< ESP32 station wps pin code in enrollee mode */
+		SYSTEM_EVENT_AP_START,	   /**< ESP32 soft-AP start */
+		SYSTEM_EVENT_AP_STOP,	   /**< ESP32 soft-AP stop */
+		SYSTEM_EVENT_AP_STACONNECTED,
+								   /**< a station connected to ESP32 soft-AP */
+		SYSTEM_EVENT_AP_STADISCONNECTED,
+	/**< a station disconnected from ESP32 soft-AP */
+		SYSTEM_EVENT_AP_STAIPASSIGNED,
+								   /**< ESP32 soft-AP assign an IP to a connected station */
+		SYSTEM_EVENT_AP_PROBEREQRECVED,
+								   /**< Receive probe request packet in soft-AP interface */
+		SYSTEM_EVENT_GOT_IP6,	   /**< ESP32 station or ap or ethernet interface v6IP addr is preferred */
+		SYSTEM_EVENT_ETH_START,	   /**< ESP32 ethernet start */
+		SYSTEM_EVENT_ETH_STOP,	   /**< ESP32 ethernet stop */
+		SYSTEM_EVENT_ETH_CONNECTED,/**< ESP32 ethernet phy link up */
+		SYSTEM_EVENT_ETH_DISCONNECTED,
+								   /**< ESP32 ethernet phy link down */
+		SYSTEM_EVENT_ETH_GOT_IP,   /**< ESP32 ethernet got IP from connected AP */
+		SYSTEM_EVENT_MAX
+	} system_event_id_t;
+
+/* add this macro define for compatible with old IDF version */
+#ifndef SYSTEM_EVENT_AP_STA_GOT_IP6
+#define SYSTEM_EVENT_AP_STA_GOT_IP6 SYSTEM_EVENT_GOT_IP6
+#endif
+
+	typedef enum {
+		WPS_FAIL_REASON_NORMAL = 0,		  /**< ESP32 WPS normal fail reason */
+		WPS_FAIL_REASON_RECV_M2D,			/**< ESP32 WPS receive M2D frame */
+		WPS_FAIL_REASON_MAX
+	} system_event_sta_wps_fail_reason_t;
+	typedef struct {
+		uint32_t status;
+					  /**< status of scanning APs */
+		uint8_t number;
+		uint8_t scan_id;
+	} system_event_sta_scan_done_t;
+
+	typedef struct {
+		uint8_t ssid[32];
+					  /**< SSID of connected AP */
+		uint8_t ssid_len;
+					  /**< SSID length of connected AP */
+		uint8_t bssid[6];
+					  /**< BSSID of connected AP*/
+		uint8_t channel;
+					  /**< channel of connected AP*/
+		wifi_auth_mode_t authmode;
+	} system_event_sta_connected_t;
+
+	typedef struct {
+		uint8_t ssid[32];
+					  /**< SSID of disconnected AP */
+		uint8_t ssid_len;
+					  /**< SSID length of disconnected AP */
+		uint8_t bssid[6];
+					  /**< BSSID of disconnected AP */
+		uint8_t reason;
+					  /**< reason of disconnection */
+	} system_event_sta_disconnected_t;
+
+	typedef struct {
+		wifi_auth_mode_t old_mode;
+							   /**< the old auth mode of AP */
+		wifi_auth_mode_t new_mode;
+							   /**< the new auth mode of AP */
+	} system_event_sta_authmode_change_t;
+
+	typedef struct {
+		tcpip_adapter_ip_info_t ip_info;
+		bool ip_changed;
+	} system_event_sta_got_ip_t;
+
+	typedef struct {
+		uint8_t pin_code[8];
+						 /**< PIN code of station in enrollee mode */
+	} system_event_sta_wps_er_pin_t;
+
+	typedef struct {
+		tcpip_adapter_if_t if_index;
+		tcpip_adapter_ip6_info_t ip6_info;
+	} system_event_got_ip6_t;
+
+	typedef struct {
+		uint8_t mac[6];
+					  /**< MAC address of the station connected to ESP32 soft-AP */
+		uint8_t aid;  /**< the aid that ESP32 soft-AP gives to the station connected to  */
+	} system_event_ap_staconnected_t;
+
+	typedef struct {
+		uint8_t mac[6];
+					  /**< MAC address of the station disconnects to ESP32 soft-AP */
+		uint8_t aid;  /**< the aid that ESP32 soft-AP gave to the station disconnects to  */
+	} system_event_ap_stadisconnected_t;
+
+	typedef struct {
+		int rssi;	  /**< Received probe request signal strength */
+		uint8_t mac[6];
+					  /**< MAC address of the station which send probe request */
+	} system_event_ap_probe_req_rx_t;
+
+	typedef union {
+		system_event_sta_connected_t connected;			   /**< ESP32 station connected to AP */
+		system_event_sta_disconnected_t disconnected;	   /**< ESP32 station disconnected to AP */
+		system_event_sta_scan_done_t scan_done;			   /**< ESP32 station scan (APs) done */
+		system_event_sta_authmode_change_t auth_change;	   /**< the auth mode of AP ESP32 station connected to changed */
+		system_event_sta_got_ip_t got_ip;				   /**< ESP32 station got IP, first time got IP or when IP is changed */
+		system_event_sta_wps_er_pin_t sta_er_pin;		   /**< ESP32 station WPS enrollee mode PIN code received */
+		system_event_sta_wps_fail_reason_t sta_er_fail_reason;
+														  /**< ESP32 station WPS enrollee mode failed reason code received */
+		system_event_ap_staconnected_t sta_connected;	   /**< a station connected to ESP32 soft-AP */
+		system_event_ap_stadisconnected_t sta_disconnected;/**< a station disconnected to ESP32 soft-AP */
+		system_event_ap_probe_req_rx_t ap_probereqrecved;  /**< ESP32 soft-AP receive probe request packet */
+		system_event_got_ip6_t got_ip6;					   /**< ESP32 station　or ap or ethernet ipv6 addr state change to preferred */
+	} system_event_info_t;
+
+	typedef struct {
+		system_event_id_t event_id;
+								 /**< event ID */
+		system_event_info_t event_info;
+	/**< event information */
+	} system_event_t;
+
+	typedef esp_err_t(*system_event_handler_t) (system_event_t * event);
+
+/**
+  * @brief  Send a event to event task
+  *
+  * @attention 1. Other task/modules, such as the TCPIP module, can call this API to send an event to event task
+  *
+  * @param  system_event_t * event : event
+  *
+  * @return ESP_OK : succeed
+  * @return others : fail
+  */
+	esp_err_t esp_event_send(system_event_t * event);
+
+/**
+  * @brief  Default event handler for system events
+  *
+  * This function performs default handling of system events.
+  * When using esp_event_loop APIs, it is called automatically before invoking the user-provided
+  * callback function.
+  *
+  * Applications which implement a custom event loop must call this function
+  * as part of event processing.
+  *
+  * @param  event pointer to event to be handled
+  * @return ESP_OK if an event was handled successfully
+  */
+	esp_err_t esp_event_process_default(system_event_t * event);
+
+/**
+  * @brief  Install default event handlers for Ethernet interface
+  *
+  */
+	void esp_event_set_default_eth_handlers(void);
+
+/**
+  * @brief  Install default event handlers for Wi-Fi interfaces (station and AP)
+  *
+  */
+	void esp_event_set_default_wifi_handlers(void);
+
+#ifdef __cplusplus
+}
+#endif
+#endif							/* __ESP_EVENT_H__ */

--- a/external/esp_idf_port/include/esp_event_loop.h
+++ b/external/esp_idf_port/include/esp_event_loop.h
@@ -1,0 +1,95 @@
+/******************************************************************
+ *
+ * Copyright 2019 Samsung Electronics All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************/
+
+// Copyright 2015-2016 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef __ESP_EVENT_LOOP_H__
+#define __ESP_EVENT_LOOP_H__
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "esp_err.h"
+#include "esp_event.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+  * @brief  Application specified event callback function
+  *
+  * @param  void *ctx : reserved for user
+  * @param  system_event_t *event : event type defined in this file
+  *
+  * @return ESP_OK : succeed
+  * @return others : fail
+  */
+	typedef esp_err_t(*system_event_cb_t) (void *ctx, system_event_t * event);
+
+/**
+  * @brief  Initialize event loop
+  *         Create the event handler and task
+  *
+  * @param  system_event_cb_t cb : application specified event callback, it can be modified by call esp_event_set_cb
+  * @param  void *ctx : reserved for user
+  *
+  * @return ESP_OK : succeed
+  * @return others : fail
+  */
+	esp_err_t esp_event_loop_init(system_event_cb_t cb, void *ctx);
+
+/**
+  * @brief  Set application specified event callback function
+  *
+  * @attention 1. If cb is NULL, means application don't need to handle
+  *               If cb is not NULL, it will be call when an event is received, after the default event callback is completed
+  *
+  * @param  system_event_cb_t cb : callback
+  * @param  void *ctx : reserved for user
+  *
+  * @return system_event_cb_t : old callback
+  */
+	system_event_cb_t esp_event_loop_set_cb(system_event_cb_t cb, void *ctx);
+
+/**
+  * @brief  Get the queue used by event loop
+  *
+  * @attention : currently this API is used to initialize "q" parameter
+  * of wifi_init structure.
+  *
+  * @return QueueHandle_t : event queue handle
+  */
+	void *esp_event_loop_get_queue(void);
+
+#ifdef __cplusplus
+}
+#endif
+#endif							/* __ESP_EVENT_LOOP_H__ */


### PR DESCRIPTION
Add ESP32 event loop code, which used for message handling from
wifi driver or other subsystem such as tcp/ip stack.